### PR TITLE
Fix: PDUSessionModifyRequest rejected due to insufficient resources with One Plus UEs when testing VoNR

### DIFF
--- a/producer/policyauthorization.go
+++ b/producer/policyauthorization.go
@@ -1847,15 +1847,11 @@ func updateQosInMedSubComp(qosData *models.QosData, comp *models.MediaComponent,
 	}
 
 	// update Downlink MBR
-	if maxBwDl == 0.0 {
-		updatedQosData.MaxbrDl = comp.MarBwDl
-	} else {
+	if maxBwDl != 0.0 {
 		updatedQosData.MaxbrDl = pcf_context.ConvertBitRateToString(maxBwDl)
 	}
 	// update Uplink MBR
-	if maxBwUl == 0.0 {
-		updatedQosData.MaxbrUl = comp.MarBwUl
-	} else {
+	if maxBwUl != 0.0 {
 		updatedQosData.MaxbrUl = pcf_context.ConvertBitRateToString(maxBwUl)
 	}
 	// if gbr == 0 then assign gbr = mbr
@@ -1866,6 +1862,11 @@ func updateQosInMedSubComp(qosData *models.QosData, comp *models.MediaComponent,
 	// update Uplink GBR
 	if minBwUl != 0.0 {
 		updatedQosData.GbrUl = pcf_context.ConvertBitRateToString(minBwUl)
+	}
+
+	if maxBwUl == 0 && maxBwDl == 0 {
+		logger.PolicyAuthorizationlog.Debugf(
+			"MediaSubComp produced zero bandwidth, keeping existing QoS unchanged")
 	}
 	return updatedQosData, ulExist, dlExist
 }


### PR DESCRIPTION
Refactor bandwidth checks to simplify logic for Downlink and Uplink MBR updates. Added logging for cases where both max bandwidth values are zero.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:
Resolves the problem where PDU Session Modify Request was rejected with “Insufficient Resources” when testing VoNR using OnePlus UEs
**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
